### PR TITLE
Allow users to configure how the login url is handled

### DIFF
--- a/addons/gift/auth/grant_flows/authorization_code_grant_flow.gd
+++ b/addons/gift/auth/grant_flows/authorization_code_grant_flow.gd
@@ -9,7 +9,7 @@ var chunks : PackedByteArray = PackedByteArray()
 
 func get_authorization_code(client_id : String, scopes : PackedStringArray, force_verify : bool = false) -> String:
 	start_tcp_server()
-	OS.shell_open("https://id.twitch.tv/oauth2/authorize?response_type=code&client_id=%s&scope=%s&redirect_uri=%s&force_verify=%s" % [client_id, " ".join(scopes).uri_encode(), redirect_url, "true" if force_verify else "false"].map(func (a : String): return a.uri_encode()))
+	_open_link("https://id.twitch.tv/oauth2/authorize?response_type=code&client_id=%s&scope=%s&redirect_uri=%s&force_verify=%s" % [client_id, " ".join(scopes).uri_encode(), redirect_url, "true" if force_verify else "false"].map(func (a : String): return a.uri_encode()))
 	print("Waiting for user to login.")
 	var code : String = await(auth_code_received)
 	server.stop()

--- a/addons/gift/auth/grant_flows/implicit_grant_flow.gd
+++ b/addons/gift/auth/grant_flows/implicit_grant_flow.gd
@@ -4,7 +4,7 @@ extends RedirectingFlow
 # Get an OAuth token from Twitch. Returns null if authentication failed.
 func login(client_id : String, scopes : PackedStringArray, force_verify : bool = false) -> UserAccessToken:
 	start_tcp_server()
-	OS.shell_open("https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=%s&force_verify=%s&redirect_uri=%s&scope=%s" % [client_id, "true" if force_verify else "false", redirect_url, " ".join(scopes)].map(func (a : String): return a.uri_encode()))
+	_open_link("https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=%s&force_verify=%s&redirect_uri=%s&scope=%s" % [client_id, "true" if force_verify else "false", redirect_url, " ".join(scopes)].map(func (a : String): return a.uri_encode()))
 	print("Waiting for user to login.")
 	var token_data : Dictionary = await(token_received)
 	server.stop()

--- a/addons/gift/auth/grant_flows/redirecting_flow.gd
+++ b/addons/gift/auth/grant_flows/redirecting_flow.gd
@@ -6,6 +6,8 @@ var server : TCPServer
 var tcp_port : int
 var redirect_url : String
 
+var open_link_callback : Callable
+
 func _init(port : int = 18297, redirect : String = "http://localhost:%s" % port) -> void:
 	tcp_port = port
 	redirect_url = redirect
@@ -60,3 +62,9 @@ func _handle_error(data : Dictionary) -> void:
 	var msg = "Error %s: %s" % [data["error"], data["error_description"]]
 	print(msg)
 	send_response("400 BAD REQUEST",  msg.to_utf8_buffer())
+
+func _open_link(url : String) -> void:
+	if (open_link_callback == null):
+		OS.shell_open(url)
+	else:
+		open_link_callback.call(url)


### PR DESCRIPTION
It would be nice if I could have the login url open in a different browser than my default, or have a custom prompt to copy from. 

Maybe there could be a better way to design this, but how about a simple optional callback the user can assign to the flow object before calling `login`?

Example:
```gdscript
var auth : ImplicitGrantFlow = ImplicitGrantFlow.new()
get_tree().process_frame.connect(auth.poll)

# Override default behavior of opening in default browser
auth.open_link_callback = func(url):
    # do something with url...

var token : UserAccessToken = await(auth.login(client_id, ["chat:read", "chat:edit"]))
# ...
```